### PR TITLE
Small changes for deployment

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ def system!(cmd)
 end
 
 desc 'Tag current HEAD and push to release branch'
-task :deploy, [:bucket] do |_t, args|
+task :deploy, [:bucket] => :redirect do |_t, args|
   fail 'No bucket specified' unless args[:bucket]
 
   # Build site
@@ -24,8 +24,6 @@ end
 task :redirect, [:bucket] do |_t, args|
   fail 'No bucket specified' unless args[:bucket]
 
-  system!('bundle exec middleman build')
-
   Bundler.with_clean_env do
     env = "S3_BUCKET=#{args[:bucket]}"
     system!("#{env} foreman run bundle exec middleman s3_redirect")
@@ -35,14 +33,14 @@ end
 namespace :deploy do
   desc 'Build and deploy site to support.aptible-staging.com'
   task :staging do
+    ENV['BASE_URL'] = 'https://support.aptible-staging.com'
     Rake::Task[:deploy].invoke('support.aptible-staging.com')
-    Rake::Task[:redirect].invoke('support.aptible-staging.com')
   end
 
   desc 'Build and deploy site to support.aptible.com'
   task :production do
+    ENV['BASE_URL'] = 'https://support.aptible.com'
     Rake::Task[:deploy].invoke('support.aptible.com')
-    Rake::Task[:redirect].invoke('support.aptible.com')
   end
 end
 

--- a/config.rb
+++ b/config.rb
@@ -9,6 +9,9 @@ set :js_dir, 'javascripts'
 set :images_dir, 'images'
 set :partials_dir, 'partials'
 
+# (Semi-) secrets
+set :swiftype_key, 'dsMEc1fYviE2ShXAjYMW'
+
 activate :syntax, line_numbers: true
 activate :directory_indexes
 

--- a/config.rb
+++ b/config.rb
@@ -11,6 +11,7 @@ set :partials_dir, 'partials'
 
 # (Semi-) secrets
 set :swiftype_key, 'dsMEc1fYviE2ShXAjYMW'
+set :base_url, ENV['BASE_URL'] || 'https://support.aptible.com'
 
 activate :syntax, line_numbers: true
 activate :directory_indexes

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -45,4 +45,4 @@
       e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
       })(window,document,'script','//s.swiftypecdn.com/install/v1/st.js','_st');
 
-      _st('install','NEY74eNs3_qYZJHP2reK');
+      _st('install','#{swiftype_key}');

--- a/source/layouts/quickstart.haml
+++ b/source/layouts/quickstart.haml
@@ -5,8 +5,6 @@
     .container
       %ol.breadcrumb
         %li
-          %a{ href: '/documentation' }Documentation
-        %li
           %a{ href: '/quickstart' }Quickstart Guides
         - if current_page.data.language
           %li

--- a/source/robots.txt
+++ b/source/robots.txt
@@ -1,0 +1,1 @@
+User-agent: *

--- a/source/sitemap.xml.haml
+++ b/source/sitemap.xml.haml
@@ -1,0 +1,12 @@
+---
+layout: false
+---
+
+!!! XML
+
+%urlset{ xlmns: 'http://www.sitemaps.org/schemas/sitemap/0.9' }
+  - sitemap.resources.each do |resource|
+    - next unless resource.ext == '.html'
+    - next if resource.path =~ /^bower_components/
+    %url
+      %loc= "#{base_url}#{resource.url}"


### PR DESCRIPTION
- Move Swiftype keys to Middleman variable
- Add dynamic sitemap (computed on build) and robots.txt (for Swiftype)
- Remove deprecated /documentation link on Quickstart guides
