### PR TITLE
Fixup page titles, use contact footer on every page

### DIFF
--- a/source/index.haml
+++ b/source/index.haml
@@ -1,8 +1,7 @@
 ---
-header_title: Aptible Support
+# title defaults to 'Aptible Support'
 header_subtitle: How can we help?
 header_search: true
-title: Aptible Support
 categories:
   quickstart:
     title: Getting Started

--- a/source/index.haml
+++ b/source/index.haml
@@ -1,5 +1,6 @@
 ---
 # title defaults to 'Aptible Support'
+header_title: Aptible Support
 header_subtitle: How can we help?
 header_search: true
 categories:
@@ -31,5 +32,3 @@ categories:
                   = partial "images/icons/#{category['svg']}"
                 .category-footer
                   .category-title= category['title']
-
-  = partial 'contact-footer'

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -8,7 +8,12 @@
     %meta{ property: 'og:title', content: current_page.data.title || 'Aptible Support' }
     %meta{ property: 'og:site_name', content: 'Aptible Support' }
     %meta{ property: 'og:image', content: 'https://www.aptible.com/assets/images/aptible-og.png'}
-    %title= @title || current_page.metadata[:locals][:title] || current_page.data.title || 'Aptible Support'
+
+    -# Use the page title if one exists, otherwise just default to 'Aptible Support'
+    - title = @title || current_page.metadata[:locals][:title] || current_page.data.title
+    - (title == nil) ? title = 'Aptible Support' : title = title + ' | Aptible Support'
+
+    %title= title
     %script{ type: 'text/javascript', src: '//use.typekit.net/hen3udh.js' }
     %link{ rel: "shortcut icon", href: "/images/favicon.ico" }
     = stylesheet_link_tag 'main'

--- a/source/layouts/topics.haml
+++ b/source/layouts/topics.haml
@@ -13,8 +13,8 @@
 
   .container
     .row
-      .col-xs-3
-        = partial 'support_sidebar'
+      .col-xs-2.hidden-xs
+        / = partial 'support_sidebar'
 
       .markdown-document
         .col-xs-7

--- a/source/partials/_footer.haml
+++ b/source/partials/_footer.haml
@@ -1,3 +1,4 @@
+= partial 'contact-footer'
 %footer.aptible-footer-small
   .container
     %img.aptible-mark{ src: '/images/aptible-mark-gray.jpg', alt: 'Aptible Support' }

--- a/source/topics/index.haml
+++ b/source/topics/index.haml
@@ -1,5 +1,5 @@
 ---
-title: Support Index
+# title defaults to 'Aptible Support'
 header_title: Aptible Support
 header_subtitle: How can we help?
 ---


### PR DESCRIPTION
@sandersonet 
1. Adds an 'Aptible Support' tag to each page title, or defaults to just that if we're the main index or /topics
2. Pulls the contact footer into the main footer. When someone gets to the end of an article and still needs help, they get a soft landing. 
