### PR TITLE
Fix SwiftType empty results UX

### DIFF
--- a/source/javascripts/search_page.coffee
+++ b/source/javascripts/search_page.coffee
@@ -1,0 +1,22 @@
+document.addEventListener 'DOMContentLoaded', ->
+  results = document.getElementById('st-results-large-container')
+  return unless results
+
+  onHashChange = (e) ->
+    display = if window.location.hash.match(/stq=/) then 'block' else 'none'
+    results.style.display = display
+
+  window.addEventListener('hashchange', onHashChange)
+  onHashChange()
+
+document.addEventListener 'DOMContentLoaded', ->
+  form = document.getElementById('large-search-form')
+  field = document.getElementById('swifttype-search-input-large')
+
+  return unless form && field
+
+  onFormSubmit = (e) ->
+    e.preventDefault()
+    document.location.href = "/search#stq=#{field.value}&stp=1"
+
+  form.addEventListener('submit', onFormSubmit)

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -34,9 +34,10 @@
               .search-bar
                 .search-bar-input
                   .input-group
-                    %input#swifttype-search-input.form-control{ placeholder: 'Search Documentation, Support, and Quickstart guides', type: 'text' }
-                    %span.input-group-addon
-                      %i.fa.fa-search
+                    %form{ action: '/search' }
+                      %input#swifttype-search-input.form-control{ name: 'search', placeholder: 'Search Documentation, Support, and Quickstart guides', type: 'text' }
+                      %button.input-group-addon{ type: 'submit' }
+                        %i.fa.fa-search
                 #st-results-container
 
     = yield

--- a/source/partials/_navbar.haml
+++ b/source/partials/_navbar.haml
@@ -13,7 +13,8 @@
         - unless current_page.data.header_search
           %li#header-search-bar
             %i.fa.fa-search#header-search-button
-            %input.form-control#swifttype-search-input
+            %form{ action: '/search' }
+              %input.form-control#swifttype-search-input{ }
             #st-results-container
         %li{ class: current_page.url =~ /quickstart/ ? 'active' : '' }= link_to 'Getting Started', '/quickstart'
         / TODO: Enable documentation section

--- a/source/search.haml
+++ b/source/search.haml
@@ -1,0 +1,20 @@
+---
+title:  Search Aptible Support
+---
+.container.no-nav
+  .row
+    .col-md-8.col-md-offset-2.col-sm-12
+      .document-hero-title
+        %h1 Search Aptible Support
+        .search-bar
+          .search-bar-input
+            .input-group
+              %form#large-search-form{ action: '/search' }
+                %input#swifttype-search-input-large.form-control{ placeholder: 'Search Documentation, Support, and Quickstart guides', type: 'text' }
+                %button.input-group-addon{ type: 'submit' }
+                  %i.fa.fa-search
+
+      #st-results-large-container
+        .loading-results
+          %i.fa.fa-spin.fa-spinner
+

--- a/source/stylesheets/_nav.scss
+++ b/source/stylesheets/_nav.scss
@@ -41,45 +41,6 @@ header.primary-header {
   }
 }
 
-.search-bar {
-  width: 700px;
-  padding: 5px;
-  background: #054e9f;
-  @include border-radius(3px);
-  margin: 40px auto 0;
-
-  .search-bar-input {
-    background: #fff;
-    @include border-radius(3px);
-  }
-
-  .input-group {
-    width: 100%;
-
-    .form-control {
-      border: 0;
-      width: 650px;
-    }
-
-    .input-group-addon {
-      background-image: linear-gradient(-180deg, #FAFAFA 0%, #E0E0E0 100%);
-      border: 0;
-      border-left: 1px solid #ddd;
-      box-shadow: inset 0px 1px 0px 0px #fff;
-      width: 40px;
-      height: 40px;
-      float: right;
-      @include border-radius(0 3px 3px 0);
-    }
-
-    i.fa {
-      margin-left: 1px;
-      color: $color-subdued;
-      vertical-align: -8px;
-    }
-  }
-}
-
 header.breadcrumbs {
   padding: 20px 0;
   border-bottom: 1px solid #f0f0f0;

--- a/source/stylesheets/_search.scss
+++ b/source/stylesheets/_search.scss
@@ -1,0 +1,135 @@
+.search-bar {
+  width: 700px;
+  padding: 4px;
+  background: #fafafa;
+  @include border-radius(3px);
+  margin: 40px auto 0;
+
+  .search-bar-input {
+    background: #fff;
+    border: 1px solid #ccc;
+    @include border-radius(3px);
+  }
+
+  .input-group {
+    width: 100%;
+
+    .form-control {
+      border: 0;
+      width: 650px;
+    }
+
+    .input-group-addon {
+      background-image: linear-gradient(-180deg, #FAFAFA 0%, #E0E0E0 100%);
+      border: 0;
+      border-left: 1px solid #ddd;
+      box-shadow: inset 0px 1px 0px 0px #fff;
+      width: 40px;
+      height: 40px;
+      float: right;
+      @include border-radius(0 3px 3px 0);
+    }
+
+    i.fa {
+      margin-left: 1px;
+      color: $color-subdued;
+      vertical-align: -1px;
+    }
+  }
+}
+
+header.primary-header {
+  .search-bar {
+    background: #054e9f;
+    padding: 5px;
+  }
+
+  .search-bar-input {
+    border: 0;
+  }
+}
+
+#st-results-large-container {
+  margin: 50px 0;
+
+  .loading-results {
+    padding: 50px 0 100px;
+  }
+
+  i.fa-spinner {
+    font-size: 20px;
+    color: $color-subdued;
+    height: 20px;
+    width: 20px;
+    display: block;
+    margin: 0 auto;
+  }
+
+  .st-search-summary {
+    border-bottom: 4px solid #f0f0f0;
+    margin: 0 0 40px;
+
+    > h2 {
+      font-size: 24px;
+      color: $color-light;
+    }
+
+    .st-query {
+      color: $color-primary;
+      font-style: none;
+      font-weight: $weight-semibold;
+    }
+  }
+
+  .st-result {
+    border-bottom: 1px solid #f0f0f0;
+    padding-bottom: 20px;
+    margin-bottom: 20px;
+
+    &.final {
+      border: 0;
+    }
+  }
+
+  .st-result-text {
+    > h3 {
+      font-size: 18px;
+      margin: 0 0 10px;
+      font-weight: $weight-semibold;
+    }
+  }
+
+  .st-snippet {
+    color: $color-subdued;
+    font-size: 15px;
+
+    em {
+      font-weight: $weight-semibold;
+      color: $color-primary;
+    }
+  }
+
+  .st-pagination {
+    border-top: 4px solid #f0f0f0;
+    padding-top: 30px;
+
+    &:empty {
+      display: none;
+    }
+
+    a.st-page {
+      display: inline-block;
+      padding: 8px 17px;
+      border-radius: 19px;
+      background: #f0f0f0;
+      color: $color-primary;
+      font-weight: $weight-semibold;
+
+      &:hover {
+        text-decoration: none;
+        background: $color-bright-blue;
+        color: #fff;
+      }
+    }
+  }
+}

--- a/source/stylesheets/main.scss
+++ b/source/stylesheets/main.scss
@@ -12,3 +12,4 @@
 @import "syntax";
 @import "mobile";
 @import "contact";
+@import "search";


### PR DESCRIPTION
This PR fixes SwiftType search inputs sitting blankly when no results match the current query.  To accomplish this, this PR wraps all search inputs with forms that will submit a hash query to a new /search page.  The /search uses the "same page" SwiftType API to generate a result set and render them inline.  

Example pages: 
![screenshot 2015-02-24 10 39 08](https://cloud.githubusercontent.com/assets/884151/6352649/25b30bda-bc12-11e4-92b1-9f1eb1b6a7c0.png)
![screenshot 2015-02-24 10 44 28](https://cloud.githubusercontent.com/assets/884151/6352648/25b0b9a2-bc12-11e4-9e7f-2ccbb1b9798f.png)
