### PR TITLE
Redirect canonical Zendesk URLs

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -70,6 +70,12 @@ end
 
 data.redirects.each do |item|
   redirect item['loc'], item['url']
+
+  # Zendesk will sometimes index slugged URLs by ID alone
+  # e.g. /hc/en-us/categories/200178460-Getting-Started ->
+  #      /hc/en-us/categories/200178460
+  match = item['loc'].match(/(^.*[0-9]{9})/)
+  redirect(match[1], item['url']) if match
 end
 
 helpers do

--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -1,5 +1,7 @@
 - loc: /hc/en-us
   url: /
+- loc: /hc/en-us/requests/new
+  url: /
 - loc: /hc/en-us/categories/200178460-Getting-Started
   url: /quickstart
 - loc: /hc/en-us/sections/200508614-Welcome-to-Aptible
@@ -75,8 +77,6 @@
 - loc: /hc/en-us/articles/202315304-What-kinds-of-support-does-Aptible-offer-
   url: /topics/account
 - loc: /hc/en-us/articles/202316094-Do-you-have-a-phone-number-I-can-call-
-  url: /
-- loc: /hc/en-us/requests/new
   url: /
 - loc: /hc/en-us/articles/202647560-How-do-I-test-that-my-VHost-is-working-before-making-DNS-changes-
   url: /topics/paas


### PR DESCRIPTION
Thanks @alexsoble for catching this! Many old Zendesk support articles are indexed by ID alone, lacking the slug portion. As a result, [many Google indexed results](https://www.google.com/search?q=aptible+migrating+from+heroku) are currently 404ing. This PR fixes that (making the assumption that Zendesk pages will have 9-digit IDs, which is the case currently).

An example of a route that 404s on production, but now works on staging, where I've deployed this:

```
/hc/en-us/articles/202638620
```
