### PR TITLE
Quickstart cleanup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,12 +36,16 @@ namespace :deploy do
   desc 'Build and deploy site to support.aptible-staging.com'
   task :staging do
     ENV['BASE_URL'] = 'https://support.aptible-staging.com'
+    ENV['SWIFTYPE_KEY'] = '6oJmuDaosp-WnxZNZcxQ'
+    ENV['SWIFTYPE_ENGINE'] = 'omxnF9kXa-PmS4uNyRSC'
     Rake::Task[:deploy].invoke('support.aptible-staging.com')
   end
 
   desc 'Build and deploy site to support.aptible.com'
   task :production do
     ENV['BASE_URL'] = 'https://support.aptible.com'
+    ENV['SWIFTYPE_KEY'] = 'dsMEc1fYviE2ShXAjYMW'
+    ENV['SWIFTYPE_ENGINE'] = 'axuhZ5Lt1ZUziN-DqxnR'
     Rake::Task[:deploy].invoke('support.aptible.com')
   end
 end

--- a/config.rb
+++ b/config.rb
@@ -28,13 +28,17 @@ data.topics.each do |title, category|
   proxy "#{category_url}/index.html",
         'topics/category.html',
         locals: { category: category, title: title },
-        ignore: true
+        ignore: true do
+    @description = "Aptible support questions about #{title}"
+  end
 
   category.articles.each do |article|
     page "topics/#{article.url}.html", layout: 'topics.haml' do
       @category_url = category_url
       @category_title = title
       @title = article.title
+      @description = 'Aptible support guides and answers'
+      @og_type = 'article'
     end
   end
 end
@@ -48,14 +52,19 @@ data.quickstart.each do |language_name, language_data|
         'quickstart/category.html',
         locals: { language: language_data },
         ignore: true do
-    @title = language_data.name + ' Quickstarts'
+    @title = "#{language_data.name} Quickstart Guides"
+    @description = "Guides for getting started with #{language_data.name} "\
+                   'on Aptible'
   end
 
   language_data.articles.each do |article|
     page "quickstart/#{article.url}.html", layout: 'quickstart.haml' do
       @framework = article.framework
       @language = language_data
-      @title = @framework + ' Quickstart'
+      @title = "#{@framework} Quickstart"
+      @description = 'Step-by-step instructions for getting started '\
+                     "with #{@framework} on Aptible"
+      @og_type = 'article'
     end
   end
 end
@@ -86,23 +95,44 @@ data.redirects.each do |item|
 end
 
 helpers do
-  def title_tag(opts = {})
+  def title_tags(opts = {})
     current_page = opts[:page]
 
-    # Quickstart articles pass @title (see ~#L55)
+    # Article pages pass @title as an option
     title = opts[:title]
 
     # Some pages also set it in front matter
     title ||= current_page.metadata[:locals][:title] ||
               current_page.data.header_title
 
+    # Some pages just have a default title, which we don't want to repeat
     if title.nil? || title == 'Aptible Support'
-      title = 'Aptible Support'
+      swiftype_title = title = 'Aptible Support'
     else
+      # Use a clean title for Swifttype
+      swiftype_title = title
       title = "#{title} | Aptible Support"
     end
 
-    "<title>#{title}</title>"
+    "<title>#{title}</title> \n" \
+    "<meta property=\"og:title\" content=\"#{title}\" > \n" \
+    "<meta class=\"swiftype\" name=\"title\" " \
+    "data-type=\"string\" content=\"#{swiftype_title}\" >"
+  end
+
+  def meta_tags(opts = {})
+    description = opts[:description]
+    og_type = opts[:og_type]
+
+    description ||= current_page.data.header_subtitle
+
+    url = "#{base_url}#{current_page.url}"
+
+    og_type = og_type.nil? ? 'website' : 'article'
+
+    "<meta property=\"og:description\" content=\"#{description}\" >\n" \
+    "<meta property=\"og:url\" content=\"#{url}\" >\n"\
+    "<meta property=\"og:type\" content=\"#{og_type}\" >"
   end
 
   def contact_href

--- a/config.rb
+++ b/config.rb
@@ -39,7 +39,7 @@ data.topics.each do |title, category|
   end
 end
 
-# Quickstart (Getting Started)
+# Quickstart Guides
 # If the language has no or only one framework, skip category page and
 # render language or framework document
 page '/quickstart/*', layout: 'quickstart.haml'

--- a/config.rb
+++ b/config.rb
@@ -10,8 +10,8 @@ set :images_dir, 'images'
 set :partials_dir, 'partials'
 
 # (Semi-) secrets
-set :swiftype_key, 'dsMEc1fYviE2ShXAjYMW'
-set :swiftype_engine, 'axuhZ5Lt1ZUziN-DqxnR'
+set :swiftype_key, ENV['SWIFTYPE_KEY'] || 'dsMEc1fYviE2ShXAjYMW'
+set :swiftype_engine, ENV['SWIFTYPE_ENGINE'] || 'axuhZ5Lt1ZUziN-DqxnR'
 set :base_url, ENV['BASE_URL'] || 'https://support.aptible.com'
 
 activate :syntax, line_numbers: true

--- a/data/quickstart.yml
+++ b/data/quickstart.yml
@@ -3,17 +3,19 @@
   svg: ruby.svg
   url: "ruby/rails"
   articles:
-    - title: "Ruby on Rails"
-      url: "ruby/rails"
-      svg: rails.svg
+    - framework: "Ruby on Rails"
       slug: "rails"
+      svg: "rails.svg"
+      url: "ruby/rails"
 
 "Go":
   slug: go
   svg: go.svg
   url: "go/gorilla"
   articles:
-    - title: "Gorilla"
+    - framework: "Gorilla"
+      slug: "gorilla"
+      svg: "go.svg"
       url: "go/gorilla"
 
 "Node":
@@ -21,28 +23,29 @@
   svg: node.svg
   url: "node/express"
   articles:
-    - title: "Express"
-      url: "node/express"
-      svg: "express.svg"
+    - framework: "Express"
       slug: "express"
+      svg: "node.svg"
+      url: "node/express"
 
 "Java":
   slug: java
   svg: java.svg
-  url: 'java/jersey'
+  url: "java/jersey"
   articles:
-    - title: "Jersey"
-      url: "java/jersey"
+    - framework: "Jersey"
+      slug: "jersey"
       svg: "java.svg"
+      url: "java/jersey"
 
 "Scala":
   slug: scala
   svg: scala.svg
   url: "scala/play"
   articles:
-    - title: "Scala Play"
-      svg: "play.svg"
+    - framework: "Scala Play"
       slug: "play"
+      svg: "play.svg"
       url: "scala/play"
 
 "PHP":
@@ -50,9 +53,9 @@
   svg: php.svg
   url: "php/laravel"
   articles:
-    - title: "Laravel"
-      svg: "laravel.svg"
+    - framework: "Laravel"
       slug: "laravel"
+      svg: "laravel.svg"
       url: "php/laravel"
 
 "Python":
@@ -60,11 +63,11 @@
   svg: python.svg
   url: 'python/django'
   articles:
-    - title: "Django"
-      url: "python/django"
-      svg: "django.svg"
+    - framework: "Django"
       slug: "django"
-    - title: "Flask"
-      url: "python/flask"
+      svg: "django.svg"
+      url: "python/django"
+    - framework: "Flask"
       slug: "flask"
       svg: "flask.svg"
+      url: "python/flask"

--- a/data/quickstart.yml
+++ b/data/quickstart.yml
@@ -40,7 +40,7 @@
   svg: scala.svg
   url: "scala/play"
   articles:
-    - title: "Play Framework"
+    - title: "Scala Play"
       svg: "play.svg"
       slug: "play"
       url: "scala/play"

--- a/source/index.haml
+++ b/source/index.haml
@@ -5,7 +5,7 @@ header_subtitle: How can we help?
 header_search: true
 categories:
   quickstart:
-    title: Getting Started Guides
+    title: Quickstart Guides
     svg: quickstart.svg
     url: /quickstart
   # TODO: Enable documentation section

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -5,11 +5,12 @@
     %meta{ content: 'IE=edge,chrome=1', http_equiv:'X-UA-Compatible' }
     %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no' }
 
-    %meta{ property: 'og:site_name', content: 'Aptible Support' }
-    %meta{ property: 'og:image', content: 'https://www.aptible.com/assets/images/aptible-og.png'}
-
     -# see config.rb
     = title_tags({ title: @title, category: @category_title, page: current_page })
+    = meta_tags({ description: @description, og_type: @og_type })
+
+    %meta{ property: 'og:site_name', content: 'Aptible Support' }
+    %meta{ property: 'og:image', content: 'https://www.aptible.com/assets/images/aptible-og.png'}
 
     %script{ type: 'text/javascript', src: '//use.typekit.net/hen3udh.js' }
     %link{ rel: "shortcut icon", href: "/images/favicon.ico" }
@@ -39,7 +40,7 @@
                         %i.fa.fa-search
                 #st-results-container
 
-    %div{ 'data-swifttype-name' => 'body', 'data-swiftype-type' => 'text', 'data-swifttype-index' => 'true' }
+    %div{ 'data-swiftype-name' => 'body', 'data-swiftype-type' => 'text', 'data-swiftype-index' => 'true' }
       = yield
 
     = partial 'footer'

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -4,12 +4,12 @@
     %meta{ charset: 'utf-8' }
     %meta{ content: 'IE=edge,chrome=1', http_equiv:'X-UA-Compatible' }
     %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no' }
-    %meta{ name: 'description', content: 'Aptible Support Site' }
-    %meta{ property: 'og:title', content: current_page.data.title || 'Aptible Support' }
+
     %meta{ property: 'og:site_name', content: 'Aptible Support' }
     %meta{ property: 'og:image', content: 'https://www.aptible.com/assets/images/aptible-og.png'}
 
-    = title_tag({ title: @title, category: @category_title, page: current_page })
+    -# see config.rb
+    = title_tags({ title: @title, category: @category_title, page: current_page })
 
     %script{ type: 'text/javascript', src: '//use.typekit.net/hen3udh.js' }
     %link{ rel: "shortcut icon", href: "/images/favicon.ico" }
@@ -39,7 +39,8 @@
                         %i.fa.fa-search
                 #st-results-container
 
-    = yield
+    %div{ 'data-swifttype-name' => 'body', 'data-swiftype-type' => 'text', 'data-swifttype-index' => 'true' }
+      = yield
 
     = partial 'footer'
 

--- a/source/layouts/quickstart.haml
+++ b/source/layouts/quickstart.haml
@@ -16,7 +16,7 @@
     .row
       .col-xs-12.col-sm-12.col-md-8.col-md-offset-2
         .document-hero-title
-          %h1= current_page.data.title
+          %h1= current_page.data.title + " Quickstart Guide"
           - if current_page.data.subtitle
             %h2= current_page.data.subtitle
 

--- a/source/layouts/quickstart.haml
+++ b/source/layouts/quickstart.haml
@@ -1,7 +1,7 @@
 / Template: quickstart.haml
 
 = wrap_layout :layout do
-  %header.breadcrumbs{ 'data-swifttype-index' => 'false' }
+  %header.breadcrumbs{ 'data-swiftype-index' => 'false' }
     .container
       %ol.breadcrumb
         %li

--- a/source/layouts/quickstart.haml
+++ b/source/layouts/quickstart.haml
@@ -6,19 +6,17 @@
       %ol.breadcrumb
         %li
           %a{ href: '/quickstart' }Quickstart Guides
-        - if current_page.data.language
-          %li
-            %a{ href: "/quickstart/#{current_page.data.language.downcase}" }= current_page.data.language
-        %li.active= current_page.data.title
+        %li
+          %a{ href: "/quickstart/#{@language.slug}" }= @language.name
+        %li.active= @framework
 
 
   .container.no-nav
     .row
       .col-xs-12.col-sm-12.col-md-8.col-md-offset-2
         .document-hero-title
-          %h1= current_page.data.title + " Quickstart Guide"
-          - if current_page.data.subtitle
-            %h2= current_page.data.subtitle
+          %h1= @framework + " Quickstart Guide"
+          %h2= "Deploying your first " + @framework + " app on Aptible"
 
         .markdown-document
           = find_and_preserve do

--- a/source/layouts/quickstart.haml
+++ b/source/layouts/quickstart.haml
@@ -1,7 +1,7 @@
 / Template: quickstart.haml
 
 = wrap_layout :layout do
-  %header.breadcrumbs
+  %header.breadcrumbs{ 'data-swifttype-index' => 'false' }
     .container
       %ol.breadcrumb
         %li

--- a/source/layouts/topics.haml
+++ b/source/layouts/topics.haml
@@ -1,7 +1,7 @@
 / Template: topics.haml
 
 = wrap_layout :layout do
-  %header.breadcrumbs
+  %header.breadcrumbs{ 'data-swifttype-index' => 'false' }
     .container
       %ol.breadcrumb
         %li

--- a/source/layouts/topics.haml
+++ b/source/layouts/topics.haml
@@ -1,7 +1,7 @@
 / Template: topics.haml
 
 = wrap_layout :layout do
-  %header.breadcrumbs{ 'data-swifttype-index' => 'false' }
+  %header.breadcrumbs{ 'data-swiftype-index' => 'false' }
     .container
       %ol.breadcrumb
         %li

--- a/source/partials/_contact-footer.haml
+++ b/source/partials/_contact-footer.haml
@@ -6,7 +6,7 @@
           .contact-footer-icon
             %i.fa.fa-envelope-o
           .contact-footer-info
-            %h4 Feeling stuck? Contact Aptible Support
+            %h4 Feeling stuck?
             %p
               We’re here to help. Get in touch and we’ll get back to you as soon as we can.
               %a{ href: '/contact' } Contact Us

--- a/source/partials/_footer.haml
+++ b/source/partials/_footer.haml
@@ -7,9 +7,9 @@
         %strong Aptible, Inc
         © 2015
     %ul.nav.nav-pills.footer-nav.pull-right
-      / TODO: Enable documentation section
-      / %li
-      /   %a{ href: '/documentation'}Documentation
+      -# TODO: Enable documentation section
+      -# %li
+      -#   %a{ href: '/documentation'}Documentation
       %li
         %a{ href: '/topics'}Support
       %li

--- a/source/partials/_navbar.haml
+++ b/source/partials/_navbar.haml
@@ -17,6 +17,6 @@
               %input.form-control#swifttype-search-input{ }
             #st-results-container
         %li{ class: current_page.url =~ /quickstart/ ? 'active' : '' }= link_to 'Getting Started', '/quickstart'
-        / TODO: Enable documentation section
-        / %li{ class: current_page.url =~ /documentation/ ? 'active' : '' }= link_to 'Documentation', '/documentation'
+        -# TODO: Enable documentation section
+        -# %li{ class: current_page.url =~ /documentation/ ? 'active' : '' }= link_to 'Documentation', '/documentation'
         %li{ class: current_page.url =~ /topics/ ? 'active' : '' }= link_to 'Support', '/topics'

--- a/source/quickstart/category.haml
+++ b/source/quickstart/category.haml
@@ -3,7 +3,7 @@ layout: layout
 ---
 
 .documentation-main
-  %h3.sub-title Which #{title} framework are you using?
+  %h3.sub-title Which #{language.name} framework are you using?
   .container
     .categories
       .row
@@ -13,4 +13,4 @@ layout: layout
               %a.category-box{ href: "/quickstart/#{article.url}", class: article.slug }
                 .category-icon= partial "/images/icons/#{article.svg}"
                 .category-footer
-                  .category-title= article.title
+                  .category-title= article.framework

--- a/source/quickstart/go/gorilla.md
+++ b/source/quickstart/go/gorilla.md
@@ -1,6 +1,6 @@
 ---
-title: Getting Started with Go on Aptible using the Gorilla Web Toolkit
-subtitle: Deploy your Gorilla web toolkit app on Aptible in about 5 minutes
+title: Gorilla
+subtitle: Deploy your Gorilla Go app on Aptible in about 5 minutes
 ---
 
 This guide teaches you how to set up a Websockets-based chat server written in Go on Aptible, using the Gorilla web toolkit.  With additional authentication, authorization, and data persistence, this example app has the potential to become a HIPAA-compliant web chat product that might command millions of dollars in seed funding.

--- a/source/quickstart/go/gorilla.md
+++ b/source/quickstart/go/gorilla.md
@@ -1,8 +1,3 @@
----
-title: Gorilla
-subtitle: Deploy your Gorilla Go app on Aptible in about 5 minutes
----
-
 This guide teaches you how to set up a Websockets-based chat server written in Go on Aptible, using the Gorilla web toolkit.  With additional authentication, authorization, and data persistence, this example app has the potential to become a HIPAA-compliant web chat product that might command millions of dollars in seed funding.
 
 This guide assumes you have:

--- a/source/quickstart/index.haml
+++ b/source/quickstart/index.haml
@@ -1,6 +1,6 @@
 ---
-header_title: Getting Started on Aptible
-header_subtitle: Step-by-step guides for deploying your app on Aptible.
+header_title: Quickstart Guides
+header_subtitle: Step-by-step guides for getting started with Aptible
 header_search: false
 layout: layout
 ---

--- a/source/quickstart/java/jersey.md
+++ b/source/quickstart/java/jersey.md
@@ -1,8 +1,3 @@
----
-title: Java Jersey
-subtitle: Deploy your Jersey app on Aptible in about 5 minutes
----
-
 This guide will show you how to set up a Java app using the Jersey framework and PostgreSQL.
 
 This guide assumes you have:

--- a/source/quickstart/java/jersey.md
+++ b/source/quickstart/java/jersey.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started with Java on Aptible using the Jersey Framework
+title: Java Jersey
 subtitle: Deploy your Jersey app on Aptible in about 5 minutes
 ---
 

--- a/source/quickstart/node/express.md
+++ b/source/quickstart/node/express.md
@@ -1,8 +1,3 @@
----
-title: Node.js Express
-subtitle: Deploy your Express app on Aptible in about 5 minutes
----
-
 This guide will show you how to set up a Node.js app using the Express framework and the Mongoose ODM for Mongodb.
 
 This guide assumes you have:

--- a/source/quickstart/node/express.md
+++ b/source/quickstart/node/express.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started with Node.js on Aptible Using the Express Framework
+title: Node.js Express
 subtitle: Deploy your Express app on Aptible in about 5 minutes
 ---
 

--- a/source/quickstart/php/laravel.md
+++ b/source/quickstart/php/laravel.md
@@ -1,8 +1,3 @@
----
-title: PHP Laravel
-subtitle: Deploy your Laravel PHP app on Aptible in about 5 minutes
----
-
 This guide will show you how to set up a PHP app using the Laravel framework and MySQL. This guide is for Laravel 4.0 or greater.
 
 This guide assumes you have:

--- a/source/quickstart/php/laravel.md
+++ b/source/quickstart/php/laravel.md
@@ -1,6 +1,6 @@
 ---
-title: Getting Started with PHP on Aptible Using the Laravel Framework
-subtitle: Deploy your Express app on Aptible in about 5 minutes
+title: PHP Laravel
+subtitle: Deploy your Laravel PHP app on Aptible in about 5 minutes
 ---
 
 This guide will show you how to set up a PHP app using the Laravel framework and MySQL. This guide is for Laravel 4.0 or greater.

--- a/source/quickstart/python/django.md
+++ b/source/quickstart/python/django.md
@@ -1,9 +1,3 @@
----
-title: Django
-subtitle: Deploy your Django app to Aptible in about 5 minutes
-language: Python
----
-
 This guide will show you how to set up a Python app using the Django framework, Gunicorn, and PostgreSQL.
 
 This guide assumes you have:

--- a/source/quickstart/python/django.md
+++ b/source/quickstart/python/django.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started with Python on Aptible Using the Django Framework
+title: Django
 subtitle: Deploy your Django app to Aptible in about 5 minutes
 language: Python
 ---

--- a/source/quickstart/python/flask.md
+++ b/source/quickstart/python/flask.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started with Python on Aptible Using the Flask Framework
+title: Flask
 subtitle: Deploy your Flask app to Aptible in about 5 minutes
 language: Python
 ---

--- a/source/quickstart/python/flask.md
+++ b/source/quickstart/python/flask.md
@@ -1,9 +1,3 @@
----
-title: Flask
-subtitle: Deploy your Flask app to Aptible in about 5 minutes
-language: Python
----
-
 This guide will show you how to set up a Python app using the Flask framework, Gunicorn, SQLAlchemy, and PostgreSQL.
 
 This guide assumes you have:

--- a/source/quickstart/ruby/rails.md
+++ b/source/quickstart/ruby/rails.md
@@ -1,8 +1,3 @@
----
-title: Ruby on Rails
-subtitle: Deploy your Ruby on Rails app to Aptible in about 5 minutes
----
-
 This guide will show you how to set up a Ruby app using the Rails framework and ActiveRecord + PostgreSQL. This guide is for Rails 4.0 or greater. If you are on an older version of Rails, your app will need [additional configuration](http://edgeguides.rubyonrails.org/configuring.html#configuring-a-database) to connect to a database.
 
 This guide assumes you have:

--- a/source/quickstart/ruby/rails.md
+++ b/source/quickstart/ruby/rails.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started with Ruby on Aptible Using the Ruby on Rails Framework
+title: Ruby on Rails
 subtitle: Deploy your Ruby on Rails app to Aptible in about 5 minutes
 ---
 

--- a/source/quickstart/scala/play.md
+++ b/source/quickstart/scala/play.md
@@ -1,8 +1,3 @@
----
-title: Scala Play
-subtitle: Deploy your Play app on Aptible in about 5 minutes
----
-
 This guide will show you how to set up a Scala app using the Play framework and PostgreSQL.
 
 This guide assumes you have:

--- a/source/quickstart/scala/play.md
+++ b/source/quickstart/scala/play.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started with Scala on Aptible Using the Play Framework
+title: Scala Play
 subtitle: Deploy your Play app on Aptible in about 5 minutes
 ---
 


### PR DESCRIPTION
@sanderson @fancyremarker 

WHEREAS we want to have a baller support site with clean lines and no cruft,
HEREFORE BE IT RESOLVED, this PR:
- [x] DRYs up article metadata by deprecating front matter in favor of the Middleman data files
- [x] Cleans up page titles and metadata
- [x] Adds data attributes for the Swifttype crawler, for more readable, more relevant results
- [x] Adds a separate Swiftype staging environment
