### PR TITLE
Clarify autobuild default port

### DIFF
--- a/source/quickstart/node/express.md
+++ b/source/quickstart/node/express.md
@@ -45,7 +45,9 @@ Here is a sample Dockerfile that uses Aptible's `autobuild` image:
 
 Here is a sample Procfile for a Node.js app:
 
-    web: node server.js -p $PORT
+    web: node server.js
+
+_Note: If you are using the quay.io/aptible/autobuild image in your Dockerfile, port 3000 will already be exposed and set as the PORT environment variable.  Exposing or listening to another port in your app will lead to [health check failures](/topics/troubleshooting/health-check-failed/)._
 
 ## 4. Provision a Database
 

--- a/source/topics/troubleshooting/health-check-failed.md
+++ b/source/topics/troubleshooting/health-check-failed.md
@@ -4,3 +4,5 @@ If the health check fails for your app, it means that this HTTP request failed t
 
 * The app server is listening on a different port than the port exposed by the container. For example, your Dockerfile may include the instruction `EXPOSE 3000`, but your app is actually listening on port 8000. Changing the port value of `EXPOSE` instruction can fix this root cause.
 * The app server is listening only on localhost (127.0.0.1). Aptible's routing requires that the app listen on all external addresses, so your app server should be configured to listen on 0.0.0.0. Most app frameworks will be configured to listen on 0.0.0.0 by default, but if you have questions about setting it up for your app, please [contact support](https://support.aptible.com/contact).
+
+_Note: If you are using the quay.io/aptible/autobuild image in your Dockerfile, port 3000 will already be exposed and set as the PORT environment variable._


### PR DESCRIPTION
This PR clarifies a couple issues that could cause confusion for new customers.

1) The `-p` flag in node doesn't set a port like it does in rails server.
2) Added a note about the default port for the aptible/autobuild image.  Aptible will only bind to the first `EXPOSE`d port (sorted alphabetically), so if a user attempts to `EXPOSE` and bind to a port greater than 3000, they will get health check failures. 

@chasballew - Mind reviewing the copy?
