### PR TITLE
Add link to how-to-install-cli on all the quickstart pages

### DIFF
--- a/source/quickstart/go/gorilla.md
+++ b/source/quickstart/go/gorilla.md
@@ -4,7 +4,7 @@ This guide assumes you have:
 
 - An Aptible account
 - An SSH key associated with your Aptible user account
-- The Aptible command line tool installed
+- The [Aptible command line tool installed](/topics/cli/how-to-install-cli)
 
 ## 1. Get the Code
 

--- a/source/quickstart/java/jersey.md
+++ b/source/quickstart/java/jersey.md
@@ -4,7 +4,7 @@ This guide assumes you have:
 
 - An Aptible account
 - An SSH key associated with your Aptible user account
-- The Aptible command line tool installed
+- The [Aptible command line tool installed](/topics/cli/how-to-install-cli)
 
 ## 1. Provision Your App
 

--- a/source/quickstart/node/express.md
+++ b/source/quickstart/node/express.md
@@ -4,7 +4,7 @@ This guide assumes you have:
 
 - An Aptible account
 - An SSH key associated with your Aptible user account
-- The Aptible command line tool installed
+- The [Aptible command line tool installed](/topics/cli/how-to-install-cli)
 
 ## 1. Provision Your App
 

--- a/source/quickstart/php/laravel.md
+++ b/source/quickstart/php/laravel.md
@@ -2,9 +2,9 @@ This guide will show you how to set up a PHP app using the Laravel framework and
 
 This guide assumes you have:
 
-- An Aptible account,
-- An SSH key associated with your Aptible user account, and
-- The Aptible command line tool installed
+- An Aptible account
+- An SSH key associated with your Aptible user account
+- The [Aptible command line tool installed](/topics/cli/how-to-install-cli)
 
 ## 1. Provision Your App
 

--- a/source/quickstart/python/django.md
+++ b/source/quickstart/python/django.md
@@ -4,7 +4,7 @@ This guide assumes you have:
 
 - An Aptible account
 - An SSH key associated with your Aptible user account
-- The Aptible command line tool installed
+- The [Aptible command line tool installed](/topics/cli/how-to-install-cli)
 
 ## 1. Provision Your App
 

--- a/source/quickstart/python/flask.md
+++ b/source/quickstart/python/flask.md
@@ -4,7 +4,7 @@ This guide assumes you have:
 
 - An Aptible account
 - An SSH key associated with your Aptible user account
-- The Aptible command line tool installed
+- The [Aptible command line tool installed](/topics/cli/how-to-install-cli)
 
 ## 1. Provision Your App
 

--- a/source/quickstart/ruby/rails.md
+++ b/source/quickstart/ruby/rails.md
@@ -4,7 +4,7 @@ This guide assumes you have:
 
 - An Aptible account,
 - An SSH key associated with your Aptible user account, and
-- The Aptible command line tool installed
+- The [Aptible command line tool installed](/topics/cli/how-to-install-cli)
 
 ## 1. Provision Your App
 

--- a/source/quickstart/scala/play.md
+++ b/source/quickstart/scala/play.md
@@ -4,7 +4,7 @@ This guide assumes you have:
 
 - An Aptible account
 - An SSH key associated with your Aptible user account
-- The Aptible command line tool installed
+- The [Aptible command line tool installed](/topics/cli/how-to-install-cli)
 
 ## 1. Provision Your App
 


### PR DESCRIPTION
For dumb users landing on support (like me) and then immediately going to Quickstart, there's no obvious link to the CLI install guide / info. This adds it in the "what you need" bullets.
