### PR TITLE
Reference db:tunnel instructions in quick starts

### DIFF
--- a/source/quickstart/go/gorilla.md
+++ b/source/quickstart/go/gorilla.md
@@ -74,6 +74,7 @@ databaseURL := os.Getenv("DATABASE_URL")
 conn, err := db.Connect(databaseURL)
 // ...
 ```
+To connect locally, see [the `aptible db:tunnel` command](/topics/cli/how-to-connect-to-database-from-outside/).
 
 ### App secrets
 

--- a/source/quickstart/java/jersey.md
+++ b/source/quickstart/java/jersey.md
@@ -60,6 +60,8 @@ Add the connection string to your app as an environment variable:
 
     aptible config:add DATABASE_URL=$CONNECTION_STRING
 
+To connect locally, see [the `aptible db:tunnel` command](/topics/cli/how-to-connect-to-database-from-outside/).
+
 ## 5. Deploy Your App
 
 Push to the master branch of the Aptible git remote:

--- a/source/quickstart/node/express.md
+++ b/source/quickstart/node/express.md
@@ -63,6 +63,8 @@ Add the database connection string to your app as an environment variable:
 
     aptible config:add MONGODB_URL=$CONNECTION_STRING
 
+To connect locally, see [the `aptible db:tunnel` command](/topics/cli/how-to-connect-to-database-from-outside/).
+
 ## 5. Connect the Database Using Mongoose
 
 Instantiate the Mongoose connection with the $MONGODB_URL variable you loaded into your app's environment in Step 4.

--- a/source/quickstart/php/laravel.md
+++ b/source/quickstart/php/laravel.md
@@ -60,6 +60,8 @@ In order to specify a MySQL database, use the `--type` flag:
 
 `aptible db:create` will return a connection string on success. The host value is mapped to a private subnet within your stack and cannot be used to connect from the outside Internet. Your containerized app can connect, however.
 
+To connect locally, see [the `aptible db:tunnel` command](/topics/cli/how-to-connect-to-database-from-outside/).
+
 ## 4. Configure a Database Connection
 
 Add the following PHP code to your `app/config/database.php` file to extract the MySQL connection info from the `DATABASE_URL` environment config you set in step 3.

--- a/source/quickstart/python/django.md
+++ b/source/quickstart/python/django.md
@@ -63,6 +63,8 @@ To use the DATABASE_URL variable in your Django app, install the [dj-database-ur
 
     DATABASES = {'default': dj_database_url.config()}
 
+To connect locally, see [the `aptible db:tunnel` command](/topics/cli/how-to-connect-to-database-from-outside/).
+
 ## 5. Deploy Your App
 
 Push to the master branch of the Aptible git remote:

--- a/source/quickstart/python/flask.md
+++ b/source/quickstart/python/flask.md
@@ -63,6 +63,8 @@ In `config.py`:
 
     SQLALCHEMY_DATABASE_URI = os.environ['DATABASE_URL']
 
+To connect locally, see [the `aptible db:tunnel` command](/topics/cli/how-to-connect-to-database-from-outside/).
+
 ## 5. Deploy Your App
 Push to the master branch of the Aptible git remote:
 

--- a/source/quickstart/ruby/rails.md
+++ b/source/quickstart/ruby/rails.md
@@ -58,6 +58,8 @@ Add the database connection string to your app as an environment variable:
 
     aptible config:add DATABASE_URL=$CONNECTION_STRING
 
+To connect locally, see [the `aptible db:tunnel` command](/topics/cli/how-to-connect-to-database-from-outside/).
+
 ## 5. Deploy Your App
 Push to the master branch of the Aptible git remote:
 

--- a/source/quickstart/scala/play.md
+++ b/source/quickstart/scala/play.md
@@ -62,6 +62,9 @@ By default, `aptible db:create $DB_HANDLE` will provision a 10GB PostgreSQL data
 Add the database connection string to your app as an environment variable:
 
     aptible config:add DATABASE_URL=$CONNECTION_STRING
+    
+To connect locally, see [the `aptible db:tunnel` command](/topics/cli/how-to-connect-to-database-from-outside/).
+
 
 ## 5. Deploy Your App
 


### PR DESCRIPTION
Got a request for this in `#public` today. Adds a reference to the `aptible db:tunnel` FAQ in each quick start’s DB setup section with the following copy:

> To connect locally, see the `aptible db:tunnel` command

<img width="812" alt="screen shot 2015-07-14 at 4 07 30 pm" src="https://cloud.githubusercontent.com/assets/94830/8686407/4d09604a-2a43-11e5-88c3-191faefede35.png">
