### PR TITLE
Add .aptible.yml to rails quickstart

### DIFF
--- a/source/quickstart/ruby/rails.md
+++ b/source/quickstart/ruby/rails.md
@@ -60,6 +60,12 @@ Add the database connection string to your app as an environment variable:
 
 To connect locally, see [the `aptible db:tunnel` command](/topics/cli/how-to-connect-to-database-from-outside/).
 
+Most Rails applications need to run database migrations as part of their setup.
+Create an `.aptible.yml` to run migrations automatically when the app is deployed in the next step.
+
+    before_release:
+      bundle exec rake db:migrate
+
 ## 5. Deploy Your App
 Push to the master branch of the Aptible Git remote:
 


### PR DESCRIPTION
The quickstart guides don't mention adding a `.aptible.yml` file to run
database migrations. It took me a while today to figure this out on our
first deploy. The deploy will hang and then fail at `Waiting for health
check on web...` if the `Procfile` sets up a worker that calls tables
that don't exist when the app boots. The user cannot get the logs
to debug the issue without setting up papertrail since the app 
hasn't been deployed yet.

I don't know if this section should also link to
https://support.aptible.com/topics/paas/how-to-automate-database-migrations/
