### PR TITLE
Style out image from search result items

### DIFF
--- a/source/stylesheets/_search.scss
+++ b/source/stylesheets/_search.scss
@@ -91,7 +91,12 @@ header.primary-header {
     }
   }
 
+  .st-result-image {
+    display: none;
+  }
+
   .st-result-text {
+    margin-left: 0;
     > h3 {
       font-size: 18px;
       margin: 0 0 10px;


### PR DESCRIPTION
<img width="605" alt="screen shot 2015-09-18 at 12 11 28 pm" src="https://cloud.githubusercontent.com/assets/94830/9971233/8632539c-5e17-11e5-9753-92ba94a76ca7.png">
This looks like it may have been a side effect of the `aptible-sass` update. Not sure, but I hid the image...
<img width="786" alt="screen shot 2015-09-18 at 3 12 01 pm" src="https://cloud.githubusercontent.com/assets/94830/9971255/ac3a8d2a-5e17-11e5-9fed-078686f885bb.png">
