### PR TITLE
Clarify MAINTENANCE_PAGE_URL config usage / expectations

### DIFF
--- a/data/topics.yml
+++ b/data/topics.yml
@@ -94,9 +94,9 @@
       url: "paas/how-to-modify-nginx-config"
     - title: "I'm getting the error \"Validation failed: Private key must match certificate,\" what should I do?"
       url: "paas/how-to-order-certs"
-    - title: "How do I set a custom error page for my app?"
-      url: "paas/how-to-set-up-custom-error-page"
-    
+    - title: "How does the MAINTENANCE_PAGE_URL config setting work?"
+      url: "paas/how-does-the-maintenance-page-url-config-setting-work"
+
 
 "Aptible CLI":
   slug: "cli"

--- a/source/topics/paas/how-does-the-maintenance-page-url-config-setting-work.md
+++ b/source/topics/paas/how-does-the-maintenance-page-url-config-setting-work.md
@@ -1,7 +1,8 @@
 
-You can set a maintenance page URL using the Aptible CLI when you've deployed a
-version of your application that is failing. All 500 level errors will serve
-the URL set as `MAINTENANCE_PAGE_URL` until you can deploy fixes or roll your
-application back to a working state.
+Aptible can serve a maintenance page when the app itself is not responding
+(which results in a 502 error at NGiNX).
+
+You can set `MAINTENANCE_PAGE_URL` via the Aptible CLI until you can deploy
+fixes or roll your application back to a working state.
 
 `aptible config:set MAINTENANCE_PAGE_URL=[URL of static page]`

--- a/source/topics/paas/how-does-the-maintenance-page-url-config-setting-work.md
+++ b/source/topics/paas/how-does-the-maintenance-page-url-config-setting-work.md
@@ -1,6 +1,6 @@
 
 You can set a maintenance page URL using the Aptible CLI when you've deployed a
-version of your application that is failing. All 500 level errors will render
+version of your application that is failing. All 500 level errors will serve
 the URL set as `MAINTENANCE_PAGE_URL` until you can deploy fixes or roll your
 application back to a working state.
 

--- a/source/topics/paas/how-does-the-maintenance-page-url-config-setting-work.md
+++ b/source/topics/paas/how-does-the-maintenance-page-url-config-setting-work.md
@@ -2,7 +2,7 @@
 Aptible can serve a maintenance page when the app itself is not responding
 (which results in a 502 error at NGiNX).
 
-You can set `MAINTENANCE_PAGE_URL` via the Aptible CLI until you can deploy
+Set `MAINTENANCE_PAGE_URL` via the Aptible CLI until you can deploy
 fixes or roll your application back to a working state.
 
 `aptible config:set MAINTENANCE_PAGE_URL=[URL of static page]`

--- a/source/topics/paas/how-does-the-maintenance-page-url-config-setting-work.md
+++ b/source/topics/paas/how-does-the-maintenance-page-url-config-setting-work.md
@@ -1,0 +1,7 @@
+
+You can set a maintenance page URL using the Aptible CLI when you've deployed a
+version of your application that is failing. All 500 level errors will render
+the URL set as `MAINTENANCE_PAGE_URL` until you can deploy fixes or roll your
+application back to a working state.
+
+`aptible config:set MAINTENANCE_PAGE_URL=[URL of static page]`

--- a/source/topics/paas/how-to-set-up-custom-error-page.md
+++ b/source/topics/paas/how-to-set-up-custom-error-page.md
@@ -1,3 +1,0 @@
-
-You can set a maintenance page URL using the aptible CLI: `aptible config:set MAINTENANCE_PAGE_URL=[URL of static error page]`
-


### PR DESCRIPTION
This confused me. The current article mixes maintenance and custom error.
I also assumed it would put the app in a state like heroku's maintenance mode.

CC: @aaw / @fancyremarker / @wcpines 
