### PR TITLE
Remove webwidget auto-tagging to improve zd wordcloud accuracy

### DIFF
--- a/source/contact.haml
+++ b/source/contact.haml
@@ -15,7 +15,6 @@ title: Contact Us
             .col-md-6.col-xs-12
               %form#support-form{ method: 'post', action: 'https://aptible.zendesk.com/requests/embedded/create', target: 'zd-form-transport'}
                 %input{ type: 'hidden', name: 'locale_id', value: '1' }
-                %input{ type: 'hidden', name: 'set_tags', value: 'web_widget' }
                 %input{ type: 'hidden', name: 'via_id', value: '48' }
                 %input{ type: 'hidden', name: 'submitted_from', value: 'http://support.aptible.com/contact'}
 


### PR DESCRIPTION
Going to try using new tagging scheme in Zendesk, whereby we use the tag wordcloud to visualize Github issue priority. Deleting Web Widget will remove the most popular but least useful tag.  
