### PR TITLE
Deprecate autobuild

### DIFF
--- a/data/topics.yml
+++ b/data/topics.yml
@@ -2,8 +2,8 @@
   slug: "migrating"
   svg: "aptible.svg"
   articles:
-    # - title: "How do I migrate from Heroku?"
-    #   url: "migrating/how-to-migrate-from-heroku"
+    - title: "How can I use the Heroku build process with my Aptible app?"
+      url: "migrating/how-to-use-heroku-build-process"
     - title: "How do I import my existing Heroku PostgreSQL database?"
       url: "migrating/how-to-import-heroku-postgresql-database"
     # - title: "How do I import my existing MongoDB database?"

--- a/source/quickstart/java/jersey.md
+++ b/source/quickstart/java/jersey.md
@@ -38,10 +38,19 @@ A few guidelines:
 2. Place both files in the root of your repository.
 3. Be sure to commit them to version control.
 
-Here is a sample Dockerfile that uses Aptible's `autobuild` image:
+Here is a sample Dockerfile for a conventional Jersey app, on Oracle Java 8:
 
     # Dockerfile
-    FROM quay.io/aptible/autobuild
+    FROM quay.io/aptible/java:oracle-java8
+
+    RUN apt-get update && apt-get -y install maven
+
+    ADD . /app
+    WORKDIR /app
+
+    RUN mvn -Dmaven.test.skip=true install
+
+    EXPOSE 8080
 
 Here is a sample Procfile for a Jersey app:
 

--- a/source/quickstart/node/express.md
+++ b/source/quickstart/node/express.md
@@ -65,8 +65,6 @@ Here is a sample Procfile for a Node.js app:
 
     web: node server.js
 
-_Note: If you are using the quay.io/aptible/autobuild image in your Dockerfile, port 3000 will already be exposed and set as the PORT environment variable.  Exposing or listening to another port in your app will lead to [health check failures](/topics/troubleshooting/health-check-failed/)._
-
 ## 4. Provision a Database
 
 By default, `aptible db:create $DB_HANDLE` will provision a 10GB PostgreSQL database.

--- a/source/quickstart/node/express.md
+++ b/source/quickstart/node/express.md
@@ -38,10 +38,28 @@ A few guidelines:
 2. Place both files in the root of your repository.
 3. Be sure to commit them to version control.
 
-Here is a sample Dockerfile that uses Aptible's `autobuild` image:
+Here is a sample Dockerfile for a conventional Express app:
 
     # Dockerfile
-    FROM quay.io/aptible/autobuild
+    FROM quay.io/aptible/nodejs:v0.12.x
+
+    # Add package.json before rest of repo, for Docker caching purposes
+    # See http://ilikestuffblog.com/2014/01/06/
+    ADD package.json /app/
+    WORKDIR /app
+    RUN npm install --production
+
+    # If you use Bower, uncomment the following lines:
+    # ADD bower.json /app/
+    # RUN bower install --allow-root
+
+    ADD . /app
+
+    # Run any additional build commands here...
+    # grunt some:task
+
+    ENV PORT 3000
+    EXPOSE 3000
 
 Here is a sample Procfile for a Node.js app:
 

--- a/source/quickstart/python/django.md
+++ b/source/quickstart/python/django.md
@@ -14,7 +14,6 @@ Use the `apps:create` command: `aptible apps:create $APP_HANDLE`
 
 For example:
 
-
     aptible apps:create django-quickstart
 
 ## 2. Add a Git Remote
@@ -39,10 +38,34 @@ A few guidelines:
 2. Place both files in the root of your repository.
 3. Be sure to commit them to version control.
 
-Here is a sample Dockerfile that uses Aptible's `autobuild` image:
+Here is a sample Dockerfile for a conventional Django app:
 
     # Dockerfile
-    FROM quay.io/aptible/autobuild
+    FROM quay.io/aptible/ubuntu:14.04
+
+    # Basic dependencies
+    RUN apt-install build-essential python-dev python-setuptools
+    RUN apt-install libxml2-dev libxslt1-dev python-dev
+
+    # PostgreSQL dev headers and client (uncomment if you use PostgreSQL)
+    # RUN apt-install libpq-dev postgresql-client-9.3 postgresql-contrib-9.3
+
+    # MySQL dev headers (uncomment if you use MySQL)
+    # RUN apt-install libmysqlclient-dev
+
+    RUN easy_install pip
+
+    # Add requirements.txt ONLY, then run pip install, so that Docker cache won't
+    # bust when changes are made to other repo files
+    ADD requirements.txt /app/
+    WORKDIR /app
+    RUN pip install -r requirements.txt
+
+    # Add repo contents to image
+    ADD . /app/
+
+    ENV PORT 3000
+    EXPOSE 3000
 
 Here is a sample Procfile for a Django app, logging to stderr:
 

--- a/source/quickstart/python/flask.md
+++ b/source/quickstart/python/flask.md
@@ -39,10 +39,34 @@ A few guidelines:
 2. Place both files in the root of your repository.
 3. Be sure to commit them to version control.
 
-Here is a sample Dockerfile that uses Aptible's `autobuild` image:
+Here is a sample Dockerfile for a conventional Flask app:
 
     # Dockerfile
-    FROM quay.io/aptible/autobuild
+    FROM quay.io/aptible/ubuntu:14.04
+
+    # Basic dependencies
+    RUN apt-install build-essential python-dev python-setuptools
+    RUN apt-install libxml2-dev libxslt1-dev python-dev
+
+    # PostgreSQL dev headers and client (uncomment if you use PostgreSQL)
+    # RUN apt-install libpq-dev postgresql-client-9.3 postgresql-contrib-9.3
+
+    # MySQL dev headers (uncomment if you use MySQL)
+    # RUN apt-install libmysqlclient-dev
+
+    RUN easy_install pip
+
+    # Add requirements.txt ONLY, then run pip install, so that Docker cache won't
+    # bust when changes are made to other repo files
+    ADD requirements.txt /app/
+    WORKDIR /app
+    RUN pip install -r requirements.txt
+
+    # Add repo contents to image
+    ADD . /app/
+
+    ENV PORT 3000
+    EXPOSE 3000
 
 Here is a sample Procfile for a Flask app:
 

--- a/source/quickstart/ruby/rails.md
+++ b/source/quickstart/ruby/rails.md
@@ -38,10 +38,32 @@ A few guidelines:
 2. Place both files in the root of your repository.
 3. Be sure to commit them to version control.
 
-Here is a sample Dockerfile that uses Aptible's `autobuild` image:
+Here is a sample Dockerfile for a conventional Rails app:
 
     # Dockerfile
-    FROM quay.io/aptible/autobuild
+    FROM quay.io/aptible/ruby:ruby-2.2
+
+    RUN apt-get update && apt-get -y install build-essential
+
+    # System prerequisites
+    RUN apt-get update && apt-get -y install libpq-dev
+
+    # If you require additional OS dependencies, install them here:
+    # RUN apt-get update && apt-get -y install imagemagick nodejs
+
+    # Add Gemfile before rest of repo, for Docker caching purposes
+    # See http://ilikestuffblog.com/2014/01/06/
+    ADD Gemfile /app/
+    ADD Gemfile.lock /app/
+    WORKDIR /app
+    RUN bundle install
+
+    ADD . /app
+    RUN bundle exec rake assets:precompile
+
+    ENV PORT 3000
+    EXPOSE 3000
+
 
 Here is a sample Procfile for a Ruby on Rails app:
 

--- a/source/topics/migrating/how-to-use-heroku-build-process.md
+++ b/source/topics/migrating/how-to-use-heroku-build-process.md
@@ -1,0 +1,13 @@
+Aptible is built on top of Docker, and so we recommend using a [Dockerfile](https://docs.docker.com/reference/builder/), placed at the top level of your repo, to build your app.
+
+To make migrating from Heroku as easy as possible, we maintain an "Autobuild" image that uses the [buildstep](https://github.com/progrium/buildstep) framework to automatically build apps using [Heroku buildpacks](https://devcenter.heroku.com/articles/buildpacks).
+
+To use Autobuild, just add the following Dockerfile to the top level of your repo, and use the same Procfile you've been using on Heroku:
+
+    # Dockerfile
+    FROM quay.io/aptible/autobuild
+
+_Note:_ The buildstep framework will attempt to determine the type of your app automatically. You can override this by including a `.buildpacks` file at the top level of your repo. The `.buildpacks` file should contain the (HTTP) URLs of the buildpack Git repo(s) your app depends upon. For example:
+
+    https://github.com/heroku/heroku-buildpack-ruby.git
+    https://github.com/heroku/heroku-buildpack-nodejs.git


### PR DESCRIPTION
cc: @gib @wcpines 

This covers most of #157, and gets rid of all references to autobuild in Quickstart guides. I've tested all of these, roughly. I'm least confident in the Play guide, but we can tweak as we go.
