### PR TITLE
Add more explicit instructions to db:tunnel

### DIFF
--- a/source/topics/cli/how-to-connect-to-database-from-outside.md
+++ b/source/topics/cli/how-to-connect-to-database-from-outside.md
@@ -14,14 +14,6 @@ Open a separate terminal window and, depending on the database type:
 
 OR
 
-- Use the port, host, user, and password contained within the connection URL, e.g.
+- Use the port, host, user, and password printed in the `db:tunnel` output.
 
-      mongo localhost:[PORT]/db -u aptible -p [PASSWORD]
 
-For non-CLI database clients, the required arguments are the same:
-
-      Host: 127.0.0.1 
-      Port: [PORT]
-      Username: aptible
-      Password: [PASSWORD]
-      Database: db

--- a/source/topics/cli/how-to-connect-to-database-from-outside.md
+++ b/source/topics/cli/how-to-connect-to-database-from-outside.md
@@ -6,4 +6,16 @@ To connect to your Aptible database from outside Aptible's private cloud, use th
 
 This will create a secure (SSH) tunnel to your database and print a local URL where you can connect to the database.
 
-Open a separate terminal window and pass in the URL using the appropriate database client. 
+Open a separate terminal window and, depending on the database type:
+
+- Pass in the entire URL, e.g. 
+
+      psql postgresql://aptible:[PASSWORD]@127.0.0.1:[PORT]/db
+
+OR
+
+- Use the port, host, user, and password contained within the connection URL, e.g.
+
+      mongo localhost:[PORT]/db -u aptible -p [PASSWORD]
+
+

--- a/source/topics/cli/how-to-connect-to-database-from-outside.md
+++ b/source/topics/cli/how-to-connect-to-database-from-outside.md
@@ -18,4 +18,10 @@ OR
 
       mongo localhost:[PORT]/db -u aptible -p [PASSWORD]
 
+For non-CLI database clients, the required arguments are the same:
 
+      Host: 127.0.0.1 
+      Port: [PORT]
+      Username: aptible
+      Password: [PASSWORD]
+      Database: db

--- a/source/topics/cli/how-to-connect-to-database-from-outside.md
+++ b/source/topics/cli/how-to-connect-to-database-from-outside.md
@@ -10,7 +10,7 @@ Open a separate terminal window and, depending on the database type:
 
 - Pass in the entire URL, e.g. 
 
-      psql postgresql://aptible:[PASSWORD]@127.0.0.1:[PORT]/db
+        psql postgresql://aptible:[PASSWORD]@127.0.0.1:[PORT]/db
 
 OR
 

--- a/source/topics/paas/how-to-set-up-papertrail.md
+++ b/source/topics/paas/how-to-set-up-papertrail.md
@@ -15,3 +15,5 @@ Once you click "Create", you'll see a message specifying a host and port for you
 Note the host and port, and return to the [Aptible Dashboard](https://dashboard.aptible.com). Click on the "Logging" tab from within the environment for which you'd like to set up log draining, then click "Add Log Drain". In the next dialog, enter the host and port from the previous step for the "remote syslog host" and "remote syslog port," respectively.
 
 You should begin to see your app's logs in Papertrail in the next several minutes.
+
+Don't see your logs?  Make sure you're sending them to `stdout` or `stderr`.  


### PR DESCRIPTION
Should eliminate any confusion about how this is performed. 
