### PR TITLE
Document workaround for --unshallow missing

### DIFF
--- a/source/topics/troubleshooting/could-not-read-shallow-clone.md
+++ b/source/topics/troubleshooting/could-not-read-shallow-clone.md
@@ -17,4 +17,10 @@ to Aptible:
 
     git fetch --unshallow || true
 
+Note that if your CI platform uses an old version of git, `--unshallow` may not be
+available.  In that case, you can try fetching a number of commits large enough
+to fetch all commits through to the repository root, thus unshallowing your repository:
+
+    git fetch --depth=1000000
+
   [0]: https://www.perforce.com/blog/141218/git-beyond-basics-using-shallow-clones


### PR DESCRIPTION
As per: https://aptible.slack.com/archives/public/p1453402493003014
