### PR TITLE
Update tutorials to use Ruby 2.3 image

### DIFF
--- a/source/quickstart/ruby/rails.md
+++ b/source/quickstart/ruby/rails.md
@@ -41,7 +41,7 @@ A few guidelines:
 Here is a sample Dockerfile for a conventional Rails app:
 
     # Dockerfile
-    FROM quay.io/aptible/ruby:ruby-2.2
+    FROM quay.io/aptible/ruby:2.3
 
     RUN apt-get update && apt-get -y install build-essential
 

--- a/source/topics/paas/how-to-set-up-bundler-caching.md
+++ b/source/topics/paas/how-to-set-up-bundler-caching.md
@@ -1,7 +1,7 @@
 In order for the Docker build cache to cache gems installed via Bundler, it's necessary to add the Gemfile and Gemfile.lock files to the image, and run `bundle install`, _before_ adding the rest of the repo (via `ADD .`). Here's an example of how that might look in a Dockerfile:
 
 ```
-FROM quay.io/aptible/ruby:ruby-2.2
+FROM quay.io/aptible/ruby:2.3
 
 # ...
 


### PR DESCRIPTION
Let's be up to date!

Note: I removed `ruby-` bit from the tags to be consistent with what the Docker hub does, but the old tags are still available as "aliases" (https://quay.io/repository/aptible/ruby?tab=tags)
