### PR TITLE
Add about log drains page

### DIFF
--- a/data/topics.yml
+++ b/data/topics.yml
@@ -114,6 +114,8 @@
       url: "paas/how-to-auto-restart-your-app"
     - title: "How do I use PostgreSQL extensions on Aptible?"
       url: "paas/postgresql-extensions"
+    - title: "About Log Drains"
+      url: "paas/about-log-drains"
 
 "Aptible CLI":
   slug: "cli"

--- a/source/topics/paas/about-log-drains.md
+++ b/source/topics/paas/about-log-drains.md
@@ -1,0 +1,72 @@
+Log Drains let you collect logs from your apps deployed on Aptible, and route
+them to a log destination.
+
+
+## What log destinations are supported? ##
+
+Aptible can route your logs over the following protocols:
+
+### Syslog ###
+
+Syslog drains forward your logs to an external syslog server. Syslog drains
+are typically used with a hosted syslog service, such as Papertrail.
+
+See our [How do I set up Papertrail for my Aptible apps?][10] guide for more
+information.
+
+**Do note that only syslog over TCP + TLS is supported**.
+
+### Elasticsearch ###
+
+Elasticsearch drains forward your logs to an Elasticsearch instance hosted on
+Aptible.
+
+See our [How do I set up my own logging stack?][20] guide for more information.
+
+### HTTPS ###
+
+HTTPS log drains forward your logs to an arbitrary host over HTTPS.
+
+See our [How do I setup a HTTPS log drain?][30] guide for more information.
+
+
+## What is collected? ##
+
+Aptible collects the `stdout` and `stderr` streams from your containers. This
+has two important implications:
+
+- Anything you write to `stdout` and `stderr` is eventually relayed to your log
+  destination. This means that **unless you are filtering PHI out of your logs,
+  you must either self-host your log destination (e.g. use ElasticSearch hosted
+  on Aptible), or have a BAA in place with your provider**.
+- Log output sent to files is **not** captured by Aptible: if you need something
+  to show in your Aptible logs, it **must** be sent to `stdout` or `stderr`.
+
+
+## How do Log Drains work? ##
+
+First, a centralized collector is deployed for each individual Log Drain you
+configure in your Aptible environment. The collector's responsibility is to
+receive application logs from log forwarders, and route them to your log
+destination.
+
+Then, every time you launch or restart an app, Aptible deploys log forwarders
+that capture log output from your app containers and relay it to your
+centralized collector.
+
+Note that [you can restart the collector and its associated log forwarders at
+any time via your Dashboard][40].
+
+
+### Legacy Aptible "v1" stacks ###
+
+On Aptible legacy "v1" stacks, there is only one collector for all your Log
+Drains. This can cause log routing to crash if one log destination is
+unavailable. If you are still using a v1 stack, we recommend upgrading to a v2
+stack, where log forwarding is more reliable.
+
+
+  [10]: /topics/paas/how-to-set-up-papertrail/
+  [20]: /topics/paas/how-to-set-up-your-own-logging-stack/
+  [30]: /topics/paas/how-do-i-setup-a-https-log-drain/
+  [40]: /topics/troubleshooting/how-to-restart-your-log-drain/

--- a/source/topics/paas/how-do-i-setup-a-https-log-drain.md
+++ b/source/topics/paas/how-do-i-setup-a-https-log-drain.md
@@ -1,4 +1,4 @@
-By default, Aptible lets you ship your logs to a syslog or ElasticSearch
+By default, Aptible lets you ship your logs to a syslog or Elasticsearch
 endpoint, however, if you'd like more control, you can ship your logs to
 an arbitrary HTTPS endpoint instead.
 
@@ -10,7 +10,7 @@ a logging endpoint.
 
 A good choice here is to use Logstash, which lets you pre-process your logs
 (e.g. enrich, filter), and deliver them to an arbitrary destination (which could
-be an ElasticSearch instance deployed on Aptible!).
+be an Elasticsearch instance deployed on Aptible!).
 
 To make this easier, we're providing a pre-configured Logstash instance at
 [aptible/docker-logstash][10], which you can deploy on Aptible. Simply follow


### PR DESCRIPTION
This adds a page that explains what Log Drains are and how they work. It's mostly intended to be used a reference to route to other guides we already have about other Log Drain types.

Perhaps we'd also want to include a note about @aaw's new log backup feature as well?

cc @fancyremarker @wcpines 
