### PR TITLE
ALLOW_OVERRIDE should be set for Laravel

### DIFF
--- a/source/quickstart/php/laravel.md
+++ b/source/quickstart/php/laravel.md
@@ -32,6 +32,7 @@ Here is a sample Dockerfile for a Laravel app:
 
     # Dockerfile
     FROM tutum/apache-php
+    ENV ALLOW_OVERRIDE true
     RUN apt-get update && apt-get install -yq git php5-mcrypt && rm -rf /var/lib/apt/lists/*
 
     RUN php5enmod mcrypt


### PR DESCRIPTION
Like most PHP frameworks, Laravel relies on a `.htaccess` file, so users
need to set `ALLOW_OVERRIDE` for things to work.
