### PR TITLE
PHP: Use getenv, not `$_ENV`

### DIFF
--- a/source/quickstart/php/laravel.md
+++ b/source/quickstart/php/laravel.md
@@ -70,7 +70,7 @@ To connect locally, see [the `aptible db:tunnel` command](/topics/cli/how-to-con
 
 Add the following PHP code to your `app/config/database.php` file to extract the MySQL connection info from the `DATABASE_URL` environment config you set in step 3.
 
-    $url = parse_url($_ENV['DATABASE_URL']);
+    $url = parse_url(getenv('DATABASE_URL'));
 
     $host = $url["host"];
     $port = $url["port"];


### PR DESCRIPTION
`$_ENV` isn't set in all SAPIs: that depends on the `variables_order`
environment variable, and by default it's set to `GPCS` for the CLI SAPI
in the tutum image, which notably does not include `E` (for ENV):

```
/etc/php5/apache2/php.ini:variables_order = "EGPCS"
/etc/php5/cli/php.ini:variables_order = "GPCS"
```

Using `getenv` is the recommended way to access environment variables in
PHP, and solves this issue.

cc @fancyremarker 
