### PR TITLE
Stub out custom database article, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Finally, start the server. You can access it at http://localhost:4567/
 First, some prerequisites:
 
 * [AWS CLI](http://aws.amazon.com/cli/), installed locally
-* Access to a sufficiently authorized pair of AWS access key credentials
+* A valid `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in your environment
 
 In [production](https://support.aptible.com) and [staging](https://support.aptible-staging.com), the support site is deployed as an S3 website (fronted by CloudFront).
 

--- a/source/topics/paas/deploy-custom-database.md
+++ b/source/topics/paas/deploy-custom-database.md
@@ -1,0 +1,1 @@
+Currently we do not support deploying custom databases on Aptible.


### PR DESCRIPTION
Stubs out the custom database article to 1) handle old links, and 2) bust cached articles on S3.

Updates the README to explicitly state which env vars are required for deployment.

cc @fancyremarker @krallin 
