### PR TITLE
Add support for hidden topics

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
     i18n (0.6.11)
     inflecto (0.0.2)
     ipaddress (0.8.0)
-    json (1.8.1)
+    json (1.8.3)
     kramdown (1.5.0)
     listen (2.8.4)
       celluloid (>= 0.15.2)
@@ -291,3 +291,6 @@ DEPENDENCIES
   rspec
   tzinfo-data
   wdm (~> 0.1.0)
+
+BUNDLED WITH
+   1.12.5

--- a/config.rb
+++ b/config.rb
@@ -34,7 +34,8 @@ data.topics.each do |title, category|
   end
 
   category.articles.each do |article|
-    page "topics/#{article.url}.html", layout: 'topics.haml' do
+    page "topics/#{article.url}.html",
+         layout: 'topics.haml', hidden: article.hidden do
       @category_url = category_url
       @category_title = title
       @title = article.title

--- a/data/topics.yml
+++ b/data/topics.yml
@@ -34,8 +34,9 @@
   articles:
     - title: "What databases does Aptible support?"
       url: "paas/what-databases-does-aptible-support"
-#   - title: "Can I deploy a custom database on Aptible?"
-#     url: "paas/deploy-custom-database"
+    - title: "Can I deploy a custom database on Aptible?"
+      url: "paas/deploy-custom-database"
+      hidden: true
     - title: "How do I add a background worker to my app?"
       url: "paas/how-to-add-background-worker"
     - title: "How do I set up Travis CI to deploy to Aptible?"

--- a/source/sitemap.xml.haml
+++ b/source/sitemap.xml.haml
@@ -6,6 +6,7 @@ layout: false
 
 %urlset{ xlmns: 'http://www.sitemaps.org/schemas/sitemap/0.9' }
   - sitemap.resources.each do |resource|
+    - next if resource.metadata[:options][:hidden]
     - next unless resource.ext == '.html'
     - next if resource.path =~ /^bower_components/
     %url

--- a/source/topics/category.haml
+++ b/source/topics/category.haml
@@ -1,3 +1,4 @@
 .category-article-list
   - (category.articles || []).each do |article|
+    - next if article.hidden
     %a.category-article{ href: "/topics/#{article.url}" }= article.title


### PR DESCRIPTION
Adding `{ hidden: true }` to a topic in data/topics.yml will now have the effect of:
- Properly rendering the topic page with the topics.haml layout
- Removing the topic page from sitemap.xml (so it won't be indexed by Google or Swiftype)
- Removing the topic page from its topic section index

cc: @chasballew @gib. This is deployed to https://support.aptible-staging.com/
