### PR TITLE
Fix a few links

### DIFF
--- a/source/partials/_navbar.haml
+++ b/source/partials/_navbar.haml
@@ -6,7 +6,7 @@
         %span.icon-bar
         %span.icon-bar
         %span.icon-bar
-      %a.navbar-brand{ href: '/' }
+      %a.navbar-brand{ href: '/', data: { turbolinks: 'false' }}
         %img{ src: '/bower_components/aptible-sass/dist/images/aptible-logo.png' }
     #primary-nav.collapse.navbar-collapse
       %ul.nav.nav-primary.navbar-nav.navbar-right

--- a/source/support/topics/paas/how-to-download-database-backup.md
+++ b/source/support/topics/paas/how-to-download-database-backup.md
@@ -1,6 +1,6 @@
 To download a database backup:
 
-1. [Restore the backup to a new database](/topics/paas/how-to-restore-from-database-backup).
+1. [Restore the backup to a new database](/support/topics/paas/how-to-restore-from-database-backup).
 2. Use the Aptible CLI to `aptible db:tunnel` and use whatever tool your database supports to dump the restored database.
 
 Remember, your restored database will count towards your container and disk usage, so deprovision it when you are done if you no longer need it.

--- a/source/support/topics/paas/how-to-download-database-backup.md
+++ b/source/support/topics/paas/how-to-download-database-backup.md
@@ -1,6 +1,6 @@
 To download a database backup:
 
-1. [Restore the backup to a new database](/paas/how-to-restore-from-database-backup).
+1. [Restore the backup to a new database](/topics/paas/how-to-restore-from-database-backup).
 2. Use the Aptible CLI to `aptible db:tunnel` and use whatever tool your database supports to dump the restored database.
 
 Remember, your restored database will count towards your container and disk usage, so deprovision it when you are done if you no longer need it.


### PR DESCRIPTION
- Prepend `/support` to an updated article link (@wcpines - I took this so you wouldn't need to rebase. I'll close https://github.com/aptible/support/pull/284).
- Turn off turbolinks for the header aptible logo link back to `/`. Since www is in a different bucket for now this prevents a weird flash the first time a user navigates there in a session.
