### PR TITLE
Overload search result page URL

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,6 +295,3 @@ DEPENDENCIES
   turbolinks
   tzinfo-data
   wdm (~> 0.1.0)
-
-BUNDLED WITH
-   1.12.5

--- a/source/javascripts/search_page.coffee
+++ b/source/javascripts/search_page.coffee
@@ -17,6 +17,6 @@ document.addEventListener 'DOMContentLoaded', ->
 
   onFormSubmit = (e) ->
     e.preventDefault()
-    document.location.href = "/support/search/#stq=#{field.value}&stp=1"
+    document.location.href = "#{Swiftype.resultPageURL}/#stq=#{field.value}&stp=1"
 
   form.addEventListener('submit', onFormSubmit)

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -24,6 +24,11 @@
 
       (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
       (w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
+      s.onload = function() {
+        setTimeout(function() {
+          Swiftype.resultPageURL = '/support/search'
+        }, 500);
+      };
       e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
       })(window,document,'script','//s.swiftypecdn.com/install/v1/st.js','_st');
 

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -21,21 +21,19 @@
       }}();
 
 
-
       (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
       (w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
-      s.onload = function() {
-        setTimeout(function() {
-          Swiftype.resultPageURL = '/support/search'
-        }, 500);
-      };
       e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
       })(window,document,'script','//s.swiftypecdn.com/install/v1/st.js','_st');
 
       try{Typekit.load();}catch(e){}
 
       $(document).on('turbolinks:load', function() {
-        _st('install','#{swiftype_key}');
+        var swiftUrl = "//s.swiftypecdn.com/install/c/widget.js?install=#{swiftype_key}"
+        var callback = function() {
+          Swiftype.resultPageURL = '/support/search'
+        }
+        _st('loadScript', swiftUrl, callback);
         analytics.page();
       });
 


### PR DESCRIPTION
This PR fixes the search result pagination by overloading the Swiftype config with the correct search path.  Ideally we'd be able to just use Swiftype admin to make this change, but that would require migrating to the V2 client and I'd prefer not to do that right now (though it may be a good idea to do this during the redesign)

---

cc @gib 
